### PR TITLE
[fix] should check if the GUI number is the pure 8-digits string

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,9 @@ export function isGuiNumberValid(input: string | number): boolean {
 
   const n = input.toString()
   const regex: RegExp = /^\d{8}$/
+  if (!regex.test(n)) {
+    return false
+  }
 
   const checksum = GUI_NUMBER_COEFFICIENTS.reduce((sum, c, index) => {
     const product = c * parseInt(n.charAt(index), 10) // Step 1

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -12,6 +12,11 @@ describe('isGuiNumValid', () => {
     expect(isGuiNumberValid(12345678)).toBe(false)
   })
 
+  it('should not accpet the arbitrary string', () => {
+    expect(isGuiNumberValid('abcdefgh')).toBe(false)
+    expect(isGuiNumberValid('7777777')).toBe(false)
+  })
+
   it('should return true if the input is correct', () => {
     expect(isGuiNumberValid('12345675')).toBe(true)
     expect(isGuiNumberValid('12345676')).toBe(true) // 6th char is 7


### PR DESCRIPTION
Forgot to call regex.test() when validating the GUI number